### PR TITLE
Bug fixed: serialize arguments for EVAL command

### DIFF
--- a/classes/mutex/PHPRedisMutex.php
+++ b/classes/mutex/PHPRedisMutex.php
@@ -64,6 +64,10 @@ class PHPRedisMutex extends RedisMutex
     protected function evalScript($redis, $script, $numkeys, array $arguments)
     {
         try {
+            for ($i = $numkeys, $iMax = \count($arguments); $i < $iMax; $i++) {
+                $arguments[$i] = $redis->_serialize($arguments[$i]);
+            }
+
             return $redis->eval($script, $arguments, $numkeys);
         } catch (RedisException $e) {
             $message = sprintf(

--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,9 @@
     "autoload": {
         "psr-4": {"malkusch\\lock\\": "classes/"}
     },
+    "autoload-dev": {
+        "psr-4": {"malkusch\\lock\\tests\\": "tests/"}
+    },
     "require": {
         "php": ">=5.6",
         "psr/log": "^1"

--- a/tests/classes/PHPRedisMutexWithoutSerialize.php
+++ b/tests/classes/PHPRedisMutexWithoutSerialize.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace malkusch\lock\tests\classes;
+
+use malkusch\lock\mutex\PHPRedisMutex;
+
+class PHPRedisMutexWithoutSerialize extends PHPRedisMutex
+{
+    protected function evalScript($redis, $script, $numkeys, array $arguments)
+    {
+        // The method WITHOUT serialize.
+        try {
+            return $redis->eval($script, $arguments, $numkeys);
+        } catch (\RedisException $e) {
+            $message = sprintf(
+                "Failed to release lock at %s",
+                $this->getRedisIdentifier($redis)
+            );
+            throw new \malkusch\lock\exception\LockReleaseException($message, 0, $e);
+        }
+    }
+}


### PR DESCRIPTION
php-redis extension does not serialize the value for the EVAL command, we need to do this manually.