### PR TITLE
php-lock/lock#19: Added a new exception

### DIFF
--- a/classes/exception/ExecutionOutsideLockException.php
+++ b/classes/exception/ExecutionOutsideLockException.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace malkusch\lock\exception;
+
+/**
+ * This exception should be thrown when for example the lock is released or
+ * times out before the synchronized code finished execution.
+ *
+ * @see \malkusch\lock\mutex\SpinlockMutex::unlock()
+ *
+ * @author Petr Levtonov <petr@levtonov.com>
+ * @license WTFPL
+ */
+class ExecutionOutsideLockException extends LockReleaseException
+{
+}

--- a/classes/mutex/SpinlockMutex.php
+++ b/classes/mutex/SpinlockMutex.php
@@ -2,9 +2,10 @@
 
 namespace malkusch\lock\mutex;
 
-use malkusch\lock\util\Loop;
-use malkusch\lock\exception\LockReleaseException;
+use malkusch\lock\exception\ExecutionOutsideLockException;
 use malkusch\lock\exception\LockAcquireException;
+use malkusch\lock\exception\LockReleaseException;
+use malkusch\lock\util\Loop;
 
 /**
  * Spinlock implementation.
@@ -79,11 +80,13 @@ abstract class SpinlockMutex extends LockMutex
         $elapsed = microtime(true) - $this->acquired;
         if ($elapsed >= $this->timeout) {
             $message = sprintf(
-                "The code executed for %d seconds. But the timeout is %d seconds.",
+                "The code executed for %.2f seconds. But the timeout is %d " .
+                "seconds. The last %.2f seconds were executed outside the lock.",
                 $elapsed,
-                $this->timeout
+                $this->timeout,
+                $elapsed - $this->timeout
             );
-            throw new LockReleaseException($message);
+            throw new ExecutionOutsideLockException($message);
         }
 
         /*

--- a/classes/mutex/SpinlockMutex.php
+++ b/classes/mutex/SpinlockMutex.php
@@ -80,8 +80,8 @@ abstract class SpinlockMutex extends LockMutex
         $elapsed = microtime(true) - $this->acquired;
         if ($elapsed >= $this->timeout) {
             $message = sprintf(
-                "The code executed for %.2f seconds. But the timeout is %d " .
-                "seconds. The last %.2f seconds were executed outside the lock.",
+                "The code executed for %.2F seconds. But the timeout is %d " .
+                "seconds. The last %.2F seconds were executed outside the lock.",
                 $elapsed,
                 $this->timeout,
                 $elapsed - $this->timeout

--- a/tests/mutex/SpinlockMutexTest.php
+++ b/tests/mutex/SpinlockMutexTest.php
@@ -68,7 +68,7 @@ class SpinlockMutexTest extends \PHPUnit_Framework_TestCase
      * Tests executing code which exceeds the timeout fails.
      *
      * @test
-     * @expectedException malkusch\lock\exception\LockReleaseException
+     * @expectedException malkusch\lock\exception\ExecutionOutsideLockException
      */
     public function testExecuteTooLong()
     {

--- a/tests/mutex/SpinlockMutexTest.php
+++ b/tests/mutex/SpinlockMutexTest.php
@@ -2,9 +2,10 @@
 
 namespace malkusch\lock\mutex;
 
+use malkusch\lock\exception\ExecutionOutsideLockException;
 use malkusch\lock\exception\LockAcquireException;
-use phpmock\phpunit\PHPMock;
 use phpmock\environment\SleepEnvironmentBuilder;
+use phpmock\phpunit\PHPMock;
 
 /**
  * Tests for SpinlockMutex.
@@ -68,13 +69,18 @@ class SpinlockMutexTest extends \PHPUnit_Framework_TestCase
      * Tests executing code which exceeds the timeout fails.
      *
      * @test
-     * @expectedException malkusch\lock\exception\ExecutionOutsideLockException
      */
     public function testExecuteTooLong()
     {
         $mutex = $this->getMockForAbstractClass(SpinlockMutex::class, ["test", 1]);
         $mutex->expects($this->any())->method("acquire")->willReturn(true);
         $mutex->expects($this->any())->method("release")->willReturn(true);
+
+        $this->expectException(ExecutionOutsideLockException::class);
+        $this->expectExceptionMessageRegExp(
+            '/The code executed for \d+\.\d+ seconds. But the timeout is 1 ' .
+            'seconds. The last \d+\.\d+ seconds were executed outside the lock./'
+        );
 
         $mutex->synchronized(function () {
             sleep(1);


### PR DESCRIPTION
- Added `ExecutionOutsideLockException` which can be thrown when the lock is released or times out before the synchronized code finished execution.
- Changed `SpinlockMutex` to use the new `ExecutionOutsideLockException` when the synchronized code executes longer than the set timeout.

Resolves php-lock/lock#19