### PR TITLE
Add ability to retrieve executed code result or exception on unlock error

### DIFF
--- a/classes/exception/LockReleaseException.php
+++ b/classes/exception/LockReleaseException.php
@@ -16,4 +16,45 @@ namespace malkusch\lock\exception;
 class LockReleaseException extends MutexException
 {
 
+    /**
+     * @var mixed
+     */
+    private $code_result;
+
+    /**
+     * @var \Throwable|null
+     */
+    private $code_exception;
+
+    /**
+     * @return mixed The return value of the executed code block.
+     */
+    public function getCodeResult()
+    {
+        return $this->code_result;
+    }
+
+    /**
+     * @param mixed $code_result The return value of the executed code block.
+     */
+    public function setCodeResult($code_result): void
+    {
+        $this->code_result = $code_result;
+    }
+
+    /**
+     * @return \Throwable|null The exception thrown by the code block or null when there was no exception.
+     */
+    public function getCodeException(): ?\Throwable
+    {
+        return $this->code_exception;
+    }
+
+    /**
+     * @param \Throwable $code_exception The exception thrown by the code block.
+     */
+    public function setCodeException(\Throwable $code_exception): void
+    {
+        $this->code_exception = $code_exception;
+    }
 }


### PR DESCRIPTION
Add ability to do this:

```php
try {
    $mutex->synchronized(function () {
        if (someCondition()) {
            throw new \DomainException();
        }

        return "result";
    });
} catch (LockReleaseException $e) {
    if ($e->getCodeException() !== null) {
        // do something with the code exception
    } else {
        $result = $e->getCodeResult();
        // do something with the code result
    }
    
    // deal with or propagate the LockReleaseException
    throw $e;
}
```