### PR TITLE
Locked timeout

### DIFF
--- a/classes/exception/LockedTimeoutException.php
+++ b/classes/exception/LockedTimeoutException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace malkusch\lock\exception;
+
+/**
+ * A locked timeout was exceeded (time to wait while locked)
+ */
+class LockedTimeoutException extends TimeoutException
+{
+}

--- a/classes/mutex/PredisMutex.php
+++ b/classes/mutex/PredisMutex.php
@@ -28,9 +28,9 @@ class PredisMutex extends RedisMutex
      *
      * @throws \LengthException The timeout must be greater than 0.
      */
-    public function __construct(array $clients, string $name, int $timeout = 3)
+    public function __construct(array $clients, string $name, int $timeout = 3, int $lockedTimeout = null)
     {
-        parent::__construct($clients, $name, $timeout);
+        parent::__construct($clients, $name, $timeout, $lockedTimeout);
     }
 
     /**

--- a/classes/mutex/RedisMutex.php
+++ b/classes/mutex/RedisMutex.php
@@ -44,9 +44,9 @@ abstract class RedisMutex extends SpinlockMutex implements LoggerAwareInterface
      *
      * @throws \LengthException The timeout must be greater than 0.
      */
-    public function __construct(array $redisAPIs, string $name, int $timeout = 3)
+    public function __construct(array $redisAPIs, string $name, int $timeout = 3, int $lockedTimeout = null)
     {
-        parent::__construct($name, $timeout);
+        parent::__construct($name, $timeout, $lockedTimeout);
 
         $this->redisAPIs = $redisAPIs;
         $this->logger    = new NullLogger();

--- a/classes/mutex/SpinlockMutex.php
+++ b/classes/mutex/SpinlockMutex.php
@@ -74,7 +74,7 @@ abstract class SpinlockMutex extends LockMutex
     protected function lock(): void
     {
         $this->start = microtime(true);
-        $this->loop->execute(function (): void  {
+        $this->loop->execute(function (): void {
             $this->acquired = microtime(true);
 
             /*

--- a/classes/mutex/SpinlockMutex.php
+++ b/classes/mutex/SpinlockMutex.php
@@ -88,7 +88,7 @@ abstract class SpinlockMutex extends LockMutex
                 $this->loop->end();
             } elseif ($this->lockedTimeout !== null) {
                 if (microtime(true) - $this->start > $this->lockedTimeout) {
-                    throw new LockedTimeoutException();
+                    throw new LockedTimeoutException("Timeout while locked of $this->lockedTimeout seconds exceeded.");
                 }
             }
         });


### PR DESCRIPTION
_Spinlock with a twist (pun intended 😉)_

**Problem:**
I needed to throw an exception if the lock is already taken, but only after a given timeout. 

**Proposed solution**
The spinlock already has its own timeout (eg: 5 seconds). With this new option: `lockedTimeout` you can now specify a timeout while lock is already taken. (eg: 3 seconds).
The process will try to acquire the lock for 3 seconds then throw an exception if it doesn't succeed.

If we specify a `lockedTimeout` of 0, the exception will be thrown immediately after the first lock acquire attempt.

This (with a `lockedTimeout` of zero) also addresses:
https://github.com/php-lock/lock/issues/21#issuecomment-394963109