### PR TITLE
Add PHP 8.4 support

### DIFF
--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -64,13 +64,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ['7.4', '8.0', '8.1', '8.2', '8.3']
+        php: ['7.4', '8.0', '8.1', '8.2', '8.3', '8.4']
         type: ['Phpunit', 'Phpunit Lowest']
         include:
           - php: 'latest'
             type: 'Phpunit Burn'
     env:
-      LOG_COVERAGE: "${{ fromJSON('{true: \"1\", false: \"\"}')[matrix.php == '8.3' && matrix.type == 'Phpunit' && (github.event_name == 'pull_request' || (github.event_name == 'push' && (github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/master')))] }}"
+      LOG_COVERAGE: "${{ fromJSON('{true: \"1\", false: \"\"}')[matrix.php == '8.4' && matrix.type == 'Phpunit' && (github.event_name == 'pull_request' || (github.event_name == 'push' && (github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/master')))] }}"
     services:
       mysql:
         image: mysql

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ php-lock/lock follows [semantic versioning][1].
 
 ## Requirements
 
- - PHP 7.4 - 8.3
+ - PHP 7.4 - 8.4
  - Optionally [nrk/predis][2] to use the Predis locks.
  - Optionally the [php-pcntl][3] extension to enable locking with `flock()`
    without busy waiting in CLI scripts.

--- a/composer.json
+++ b/composer.json
@@ -59,7 +59,7 @@
         "phpstan/phpstan-strict-rules": "^2.0",
         "phpunit/phpunit": "^9.5.25 || ^10.0 || ^11.0",
         "predis/predis": "^1.1.8",
-        "spatie/async": "^1.5"
+        "spatie/async": "dev-main#570d7a70671d22e82fe2bac2601551b82ff83af3 as 1.5.0"
     },
     "suggest": {
         "ext-igbinary": "To use this library with PHP Redis igbinary serializer enabled.",

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
     ],
     "homepage": "https://github.com/malkusch/lock",
     "require": {
-        "php": ">=7.4 <8.4",
+        "php": ">=7.4 <8.5",
         "psr/log": "^1.0 || ^2.0 || ^3.0",
         "symfony/polyfill-php80": "^1.28"
     },

--- a/composer.json
+++ b/composer.json
@@ -59,7 +59,7 @@
         "phpstan/phpstan-strict-rules": "^2.0",
         "phpunit/phpunit": "^9.5.25 || ^10.0 || ^11.0",
         "predis/predis": "^1.1.8",
-        "spatie/async": "dev-main#570d7a70671d22e82fe2bac2601551b82ff83af3 as 1.5.0"
+        "spatie/async": "^1.5"
     },
     "suggest": {
         "ext-igbinary": "To use this library with PHP Redis igbinary serializer enabled.",


### PR DESCRIPTION
WAITING ON https://github.com/spatie/async/pull/236

needs https://github.com/spatie/async/blob/1.6.1/src/Runtime/ParentRuntime.php#L29 fixed first

```
1 test triggered 1 PHP deprecation:

1) /__w/lock/lock/vendor/spatie/async/src/Runtime/ParentRuntime.php:29
Spatie\Async\Runtime\ParentRuntime::init(): Implicitly marking parameter $autoloader as nullable is deprecated, the explicit nullable type must be used instead

Triggered by:

* malkusch\lock\Tests\mutex\MutexConcurrencyTest::testHighContention#flock
  /__w/lock/lock/tests/mutex/MutexConcurrencyTest.php:94
```