### PR TITLE
More lib specific lock prefix

### DIFF
--- a/src/mutex/SpinlockMutex.php
+++ b/src/mutex/SpinlockMutex.php
@@ -17,7 +17,7 @@ use malkusch\lock\util\Loop;
 abstract class SpinlockMutex extends LockMutex
 {
     /** The prefix for the lock key. */
-    private const PREFIX = 'lock_';
+    private const PREFIX = 'php-malkusch-lock:';
 
     /** @var float The timeout in seconds a lock may live */
     private $timeout;

--- a/tests/mutex/MemcachedMutexTest.php
+++ b/tests/mutex/MemcachedMutexTest.php
@@ -39,7 +39,7 @@ class MemcachedMutexTest extends TestCase
 
         $this->memcached->expects(self::atLeastOnce())
             ->method('add')
-            ->with('lock_test', true, 2)
+            ->with('php-malkusch-lock:test', true, 2)
             ->willReturn(false);
 
         $this->mutex->synchronized(static function (): void {
@@ -56,12 +56,12 @@ class MemcachedMutexTest extends TestCase
 
         $this->memcached->expects(self::once())
             ->method('add')
-            ->with('lock_test', true, 2)
+            ->with('php-malkusch-lock:test', true, 2)
             ->willReturn(true);
 
         $this->memcached->expects(self::once())
             ->method('delete')
-            ->with('lock_test')
+            ->with('php-malkusch-lock:test')
             ->willReturn(false);
 
         $this->mutex->synchronized(static function (): void {});

--- a/tests/mutex/PredisMutexTest.php
+++ b/tests/mutex/PredisMutexTest.php
@@ -50,7 +50,7 @@ class PredisMutexTest extends TestCase
     {
         $this->client->expects(self::atLeastOnce())
             ->method('set')
-            ->with('lock_test', self::isType('string'), 'PX', 3500, 'NX')
+            ->with('php-malkusch-lock:test', self::isType('string'), 'PX', 3500, 'NX')
             ->willReturn(null);
 
         $this->logger->expects(self::never())
@@ -72,7 +72,7 @@ class PredisMutexTest extends TestCase
     {
         $this->client->expects(self::atLeastOnce())
             ->method('set')
-            ->with('lock_test', self::isType('string'), 'PX', 3500, 'NX')
+            ->with('php-malkusch-lock:test', self::isType('string'), 'PX', 3500, 'NX')
             ->willThrowException($this->createMock(PredisException::class));
 
         $this->logger->expects(self::once())
@@ -92,12 +92,12 @@ class PredisMutexTest extends TestCase
     {
         $this->client->expects(self::atLeastOnce())
             ->method('set')
-            ->with('lock_test', self::isType('string'), 'PX', 3500, 'NX')
+            ->with('php-malkusch-lock:test', self::isType('string'), 'PX', 3500, 'NX')
             ->willReturnSelf();
 
         $this->client->expects(self::once())
             ->method('eval')
-            ->with(self::anything(), 1, 'lock_test', self::isType('string'))
+            ->with(self::anything(), 1, 'php-malkusch-lock:test', self::isType('string'))
             ->willReturn(true);
 
         $executed = false;
@@ -116,12 +116,12 @@ class PredisMutexTest extends TestCase
     {
         $this->client->expects(self::atLeastOnce())
             ->method('set')
-            ->with('lock_test', self::isType('string'), 'PX', 3500, 'NX')
+            ->with('php-malkusch-lock:test', self::isType('string'), 'PX', 3500, 'NX')
             ->willReturnSelf();
 
         $this->client->expects(self::once())
             ->method('eval')
-            ->with(self::anything(), 1, 'lock_test', self::isType('string'))
+            ->with(self::anything(), 1, 'php-malkusch-lock:test', self::isType('string'))
             ->willThrowException($this->createMock(PredisException::class));
 
         $this->logger->expects(self::once())


### PR DESCRIPTION
replace #40

More specific lock prefix is vital to reduce potential collision with other libs in theory and to ease understanding of stored keys.

### BC break: Old locks are not honored after upgrade!

If locks before upgrade are needed to be honored, rename them manually.