### PR TITLE
Unify lock/unlock methods visibility

### DIFF
--- a/src/mutex/MySQLMutex.php
+++ b/src/mutex/MySQLMutex.php
@@ -30,7 +30,7 @@ class MySQLMutex extends LockMutex
     }
 
     #[\Override]
-    public function lock(): void
+    protected function lock(): void
     {
         $statement = $this->pdo->prepare('SELECT GET_LOCK(?, ?)');
 
@@ -62,7 +62,7 @@ class MySQLMutex extends LockMutex
     }
 
     #[\Override]
-    public function unlock(): void
+    protected function unlock(): void
     {
         $statement = $this->pdo->prepare('DO RELEASE_LOCK(?)');
         $statement->execute([

--- a/src/mutex/PgAdvisoryLockMutex.php
+++ b/src/mutex/PgAdvisoryLockMutex.php
@@ -31,7 +31,7 @@ class PgAdvisoryLockMutex extends LockMutex
     }
 
     #[\Override]
-    public function lock(): void
+    protected function lock(): void
     {
         $statement = $this->pdo->prepare('SELECT pg_advisory_lock(?, ?)');
 
@@ -42,7 +42,7 @@ class PgAdvisoryLockMutex extends LockMutex
     }
 
     #[\Override]
-    public function unlock(): void
+    protected function unlock(): void
     {
         $statement = $this->pdo->prepare('SELECT pg_advisory_unlock(?, ?)');
         $statement->execute([

--- a/tests/mutex/PgAdvisoryLockMutexTest.php
+++ b/tests/mutex/PgAdvisoryLockMutexTest.php
@@ -61,7 +61,7 @@ class PgAdvisoryLockMutexTest extends TestCase
                 )
             );
 
-        $this->mutex->lock();
+        \Closure::bind(static fn ($mutex) => $mutex->lock(), null, PgAdvisoryLockMutex::class)($this->mutex);
     }
 
     public function testReleaseLock(): void
@@ -95,6 +95,6 @@ class PgAdvisoryLockMutexTest extends TestCase
                 )
             );
 
-        $this->mutex->unlock();
+        \Closure::bind(static fn ($mutex) => $mutex->unlock(), null, PgAdvisoryLockMutex::class)($this->mutex);
     }
 }


### PR DESCRIPTION
In `LockMutex` these methods are protected, so keep them protected everywhere.

### BC break: You cannot call `{MySQLMutex, PgAdvisoryLockMutex}::{lock, unlock}()` methods manually

Call `{MySQLMutex, PgAdvisoryLockMutex}::synchronized` method instead.