### PR TITLE
Prefix MySQL mutex name

### DIFF
--- a/src/mutex/MySQLMutex.php
+++ b/src/mutex/MySQLMutex.php
@@ -6,6 +6,7 @@ namespace malkusch\lock\mutex;
 
 use malkusch\lock\exception\LockAcquireException;
 use malkusch\lock\exception\TimeoutException;
+use malkusch\lock\util\LockUtil;
 
 class MySQLMutex extends LockMutex
 {
@@ -21,11 +22,13 @@ class MySQLMutex extends LockMutex
     {
         $this->pdo = $PDO;
 
-        if (\strlen($name) > 64) {
-            throw new \InvalidArgumentException('The maximum length of the lock name is 64 characters');
+        $namePrefix = LockUtil::getInstance()->getKeyPrefix() . ':';
+
+        if (\strlen($name) > 64 - \strlen($namePrefix)) {
+            throw new \InvalidArgumentException('The maximum length of the lock name is ' . (64 - \strlen($namePrefix)) . ' characters');
         }
 
-        $this->name = $name;
+        $this->name = $namePrefix . $name;
         $this->timeout = $timeout;
     }
 

--- a/tests/mutex/MySQLMutexTest.php
+++ b/tests/mutex/MySQLMutexTest.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace malkusch\lock\Tests\mutex;
+
+use malkusch\lock\mutex\MySQLMutex;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class MySQLMutexTest extends TestCase
+{
+    /** @var \PDO&MockObject */
+    private $pdo;
+
+    /** @var MySQLMutex */
+    private $mutex;
+
+    #[\Override]
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->pdo = $this->createMock(\PDO::class);
+
+        $this->mutex = new MySQLMutex($this->pdo, 'test');
+    }
+
+    public function testAcquireLock(): void
+    {
+        $statement = $this->createMock(\PDOStatement::class);
+
+        $this->pdo->expects(self::once())
+            ->method('prepare')
+            ->with('SELECT GET_LOCK(?, ?)')
+            ->willReturn($statement);
+
+        $statement->expects(self::once())
+            ->method('execute')
+            ->with(['php-malkusch-lock:test', 0]);
+
+        $statement->expects(self::once())
+            ->method('fetch')
+            ->willReturn([1]);
+
+        \Closure::bind(static fn ($mutex) => $mutex->lock(), null, MySQLMutex::class)($this->mutex);
+    }
+
+    public function testReleaseLock(): void
+    {
+        $statement = $this->createMock(\PDOStatement::class);
+
+        $this->pdo->expects(self::once())
+            ->method('prepare')
+            ->with('DO RELEASE_LOCK(?)')
+            ->willReturn($statement);
+
+        $statement->expects(self::once())
+            ->method('execute')
+            ->with(['php-malkusch-lock:test']);
+
+        \Closure::bind(static fn ($mutex) => $mutex->unlock(), null, MySQLMutex::class)($this->mutex);
+    }
+}

--- a/tests/mutex/PgAdvisoryLockMutexTest.php
+++ b/tests/mutex/PgAdvisoryLockMutexTest.php
@@ -24,7 +24,7 @@ class PgAdvisoryLockMutexTest extends TestCase
 
         $this->pdo = $this->createMock(\PDO::class);
 
-        $this->mutex = new PgAdvisoryLockMutex($this->pdo, 'test' . uniqid());
+        $this->mutex = new PgAdvisoryLockMutex($this->pdo, 'test');
     }
 
     private function isPhpunit9x(): bool
@@ -43,23 +43,21 @@ class PgAdvisoryLockMutexTest extends TestCase
 
         $statement->expects(self::once())
             ->method('execute')
-            ->with(
-                self::logicalAnd(
-                    new IsType(IsType::TYPE_ARRAY),
-                    self::countOf(2),
-                    self::callback(function (...$arguments): bool {
-                        if ($this->isPhpunit9x()) { // https://github.com/sebastianbergmann/phpunit/issues/5891
-                            $arguments = $arguments[0];
-                        }
+            ->with(self::logicalAnd(
+                new IsType(IsType::TYPE_ARRAY),
+                self::countOf(2),
+                self::callback(function (...$arguments): bool {
+                    if ($this->isPhpunit9x()) { // https://github.com/sebastianbergmann/phpunit/issues/5891
+                        $arguments = $arguments[0];
+                    }
 
-                        foreach ($arguments as $v) {
-                            self::assertIsInt($v);
-                        }
+                    foreach ($arguments as $v) {
+                        self::assertIsInt($v);
+                    }
 
-                        return true;
-                    })
-                )
-            );
+                    return true;
+                })
+            ));
 
         \Closure::bind(static fn ($mutex) => $mutex->lock(), null, PgAdvisoryLockMutex::class)($this->mutex);
     }
@@ -75,25 +73,23 @@ class PgAdvisoryLockMutexTest extends TestCase
 
         $statement->expects(self::once())
             ->method('execute')
-            ->with(
-                self::logicalAnd(
-                    new IsType(IsType::TYPE_ARRAY),
-                    self::countOf(2),
-                    self::callback(function (...$arguments): bool {
-                        if ($this->isPhpunit9x()) { // https://github.com/sebastianbergmann/phpunit/issues/5891
-                            $arguments = $arguments[0];
-                        }
+            ->with(self::logicalAnd(
+                new IsType(IsType::TYPE_ARRAY),
+                self::countOf(2),
+                self::callback(function (...$arguments): bool {
+                    if ($this->isPhpunit9x()) { // https://github.com/sebastianbergmann/phpunit/issues/5891
+                        $arguments = $arguments[0];
+                    }
 
-                        foreach ($arguments as $v) {
-                            self::assertLessThan(1 << 32, $v);
-                            self::assertGreaterThan(-(1 << 32), $v);
-                            self::assertIsInt($v);
-                        }
+                    foreach ($arguments as $v) {
+                        self::assertLessThan(1 << 32, $v);
+                        self::assertGreaterThan(-(1 << 32), $v);
+                        self::assertIsInt($v);
+                    }
 
-                        return true;
-                    })
-                )
-            );
+                    return true;
+                })
+            ));
 
         \Closure::bind(static fn ($mutex) => $mutex->unlock(), null, PgAdvisoryLockMutex::class)($this->mutex);
     }


### PR DESCRIPTION
related with #59

### BC break: Old locks are not honored after upgrade!

If locks before upgrade are needed to be honored, rename them manually.