### PR TITLE
Improve PostgreSQL advisory lock key hashing

### DIFF
--- a/src/mutex/PgAdvisoryLockMutex.php
+++ b/src/mutex/PgAdvisoryLockMutex.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace malkusch\lock\mutex;
 
+use malkusch\lock\util\LockUtil;
+
 class PgAdvisoryLockMutex extends LockMutex
 {
     /** @var \PDO */
@@ -20,7 +22,7 @@ class PgAdvisoryLockMutex extends LockMutex
     {
         $this->pdo = $PDO;
 
-        [$keyBytes1, $keyBytes2] = str_split(md5($name, true), 4);
+        [$keyBytes1, $keyBytes2] = str_split(md5(LockUtil::getInstance()->getKeyPrefix() . ':' . $name, true), 4);
 
         $unpackToSignedIntFx = static function (string $v) {
             $unpacked = unpack('va/Cb/cc', $v);

--- a/src/mutex/PgAdvisoryLockMutex.php
+++ b/src/mutex/PgAdvisoryLockMutex.php
@@ -20,7 +20,7 @@ class PgAdvisoryLockMutex extends LockMutex
     {
         $this->pdo = $PDO;
 
-        [$keyBytes1, $keyBytes2] = str_split(hash('sha256', $name, true), 4);
+        [$keyBytes1, $keyBytes2] = str_split(md5($name, true), 4);
 
         $unpackToSignedIntFx = static function (string $v) {
             $unpacked = unpack('va/Cb/cc', $v);

--- a/src/mutex/PgAdvisoryLockMutex.php
+++ b/src/mutex/PgAdvisoryLockMutex.php
@@ -24,14 +24,15 @@ class PgAdvisoryLockMutex extends LockMutex
 
         [$keyBytes1, $keyBytes2] = str_split(md5(LockUtil::getInstance()->getKeyPrefix() . ':' . $name, true), 4);
 
-        $unpackToSignedIntFx = static function (string $v) {
+        // https://github.com/php/php-src/issues/17068
+        $unpackToSignedIntLeFx = static function (string $v) {
             $unpacked = unpack('va/Cb/cc', $v);
 
-            return ($unpacked['c'] << 24) | ($unpacked['b'] << 16) | $unpacked['a'];
+            return $unpacked['a'] | ($unpacked['b'] << 16) | ($unpacked['c'] << 24);
         };
 
-        $this->key1 = $unpackToSignedIntFx($keyBytes1);
-        $this->key2 = $unpackToSignedIntFx($keyBytes2);
+        $this->key1 = $unpackToSignedIntLeFx($keyBytes1);
+        $this->key2 = $unpackToSignedIntLeFx($keyBytes2);
     }
 
     #[\Override]

--- a/tests/mutex/PgAdvisoryLockMutexTest.php
+++ b/tests/mutex/PgAdvisoryLockMutexTest.php
@@ -24,7 +24,7 @@ class PgAdvisoryLockMutexTest extends TestCase
 
         $this->pdo = $this->createMock(\PDO::class);
 
-        $this->mutex = new PgAdvisoryLockMutex($this->pdo, 'test');
+        $this->mutex = new PgAdvisoryLockMutex($this->pdo, 'test-one-negative-key');
     }
 
     private function isPhpunit9x(): bool
@@ -59,7 +59,7 @@ class PgAdvisoryLockMutexTest extends TestCase
 
                     return true;
                 }),
-                [355884658, 1705446324]
+                [533558444, -1716795572]
             ));
 
         \Closure::bind(static fn ($mutex) => $mutex->lock(), null, PgAdvisoryLockMutex::class)($this->mutex);
@@ -92,7 +92,7 @@ class PgAdvisoryLockMutexTest extends TestCase
 
                     return true;
                 }),
-                [355884658, 1705446324]
+                [533558444, -1716795572]
             ));
 
         \Closure::bind(static fn ($mutex) => $mutex->unlock(), null, PgAdvisoryLockMutex::class)($this->mutex);

--- a/tests/mutex/PgAdvisoryLockMutexTest.php
+++ b/tests/mutex/PgAdvisoryLockMutexTest.php
@@ -52,11 +52,14 @@ class PgAdvisoryLockMutexTest extends TestCase
                     }
 
                     foreach ($arguments as $v) {
+                        self::assertLessThan(1 << 32, $v);
+                        self::assertGreaterThanOrEqual(-(1 << 32), $v);
                         self::assertIsInt($v);
                     }
 
                     return true;
-                })
+                }),
+                [-2117040481, 1702710408]
             ));
 
         \Closure::bind(static fn ($mutex) => $mutex->lock(), null, PgAdvisoryLockMutex::class)($this->mutex);
@@ -83,12 +86,13 @@ class PgAdvisoryLockMutexTest extends TestCase
 
                     foreach ($arguments as $v) {
                         self::assertLessThan(1 << 32, $v);
-                        self::assertGreaterThan(-(1 << 32), $v);
+                        self::assertGreaterThanOrEqual(-(1 << 32), $v);
                         self::assertIsInt($v);
                     }
 
                     return true;
-                })
+                }),
+                [-2117040481, 1702710408]
             ));
 
         \Closure::bind(static fn ($mutex) => $mutex->unlock(), null, PgAdvisoryLockMutex::class)($this->mutex);

--- a/tests/mutex/PgAdvisoryLockMutexTest.php
+++ b/tests/mutex/PgAdvisoryLockMutexTest.php
@@ -59,7 +59,7 @@ class PgAdvisoryLockMutexTest extends TestCase
 
                     return true;
                 }),
-                [-848589047, 1943216454]
+                [355884658, 1705446324]
             ));
 
         \Closure::bind(static fn ($mutex) => $mutex->lock(), null, PgAdvisoryLockMutex::class)($this->mutex);
@@ -92,7 +92,7 @@ class PgAdvisoryLockMutexTest extends TestCase
 
                     return true;
                 }),
-                [-848589047, 1943216454]
+                [355884658, 1705446324]
             ));
 
         \Closure::bind(static fn ($mutex) => $mutex->unlock(), null, PgAdvisoryLockMutex::class)($this->mutex);

--- a/tests/mutex/PgAdvisoryLockMutexTest.php
+++ b/tests/mutex/PgAdvisoryLockMutexTest.php
@@ -59,7 +59,7 @@ class PgAdvisoryLockMutexTest extends TestCase
 
                     return true;
                 }),
-                [-2117040481, 1702710408]
+                [-848589047, 1943216454]
             ));
 
         \Closure::bind(static fn ($mutex) => $mutex->lock(), null, PgAdvisoryLockMutex::class)($this->mutex);
@@ -92,7 +92,7 @@ class PgAdvisoryLockMutexTest extends TestCase
 
                     return true;
                 }),
-                [-2117040481, 1702710408]
+                [-848589047, 1943216454]
             ));
 
         \Closure::bind(static fn ($mutex) => $mutex->unlock(), null, PgAdvisoryLockMutex::class)($this->mutex);


### PR DESCRIPTION
related with https://github.com/php-lock/lock/pull/59

Use `md5` hashing which is considerably faster than `sha256` as PostgreSQL does not support more than 8 bytes anyway.

Also make the locks stable across machines with different endianness.

### BC break: Locks before upgrade are not honored after upgrade!

If locks before upgrade are needed to be honored, rename them manually.