### PR TITLE
Fix float to int casting and improve timeout names

### DIFF
--- a/src/Exception/LockReleaseException.php
+++ b/src/Exception/LockReleaseException.php
@@ -9,8 +9,9 @@ namespace Malkusch\Lock\Exception;
  *
  * Take this exception very serious.
  *
- * Failing to release a lock might have the potential to introduce deadlocks. Also the
- * critical code was executed i.e. side effects may have happened.
+ * This exception implies that the critical code was executed, i.e. side effects may have happened.
+ *
+ * Failing to release a lock might have the potential to introduce deadlocks.
  */
 class LockReleaseException extends MutexException
 {
@@ -20,9 +21,9 @@ class LockReleaseException extends MutexException
     private ?\Throwable $codeException = null;
 
     /**
-     * Gets the result that has been returned during the critical code execution.
+     * The return value of the executed critical code.
      *
-     * @return mixed The return value of the executed code block
+     * @return mixed
      */
     public function getCodeResult()
     {
@@ -42,7 +43,7 @@ class LockReleaseException extends MutexException
     }
 
     /**
-     * Gets the exception that has happened during the synchronized code execution.
+     * The exception that has happened during the critical code execution.
      */
     public function getCodeException(): ?\Throwable
     {

--- a/src/Mutex/AbstractLockMutex.php
+++ b/src/Mutex/AbstractLockMutex.php
@@ -15,7 +15,7 @@ use Malkusch\Lock\Exception\LockReleaseException;
 abstract class AbstractLockMutex extends AbstractMutex
 {
     /**
-     * Acquires the lock.
+     * Acquire a lock.
      *
      * This method blocks until the lock was acquired.
      *
@@ -24,39 +24,39 @@ abstract class AbstractLockMutex extends AbstractMutex
     abstract protected function lock(): void;
 
     /**
-     * Releases the lock.
+     * Release the lock.
      *
      * @throws LockReleaseException The lock could not be released
      */
     abstract protected function unlock(): void;
 
     #[\Override]
-    public function synchronized(callable $code)
+    public function synchronized(callable $fx)
     {
         $this->lock();
 
-        $codeResult = null;
-        $codeException = null;
+        $fxResult = null;
+        $fxException = null;
         try {
-            $codeResult = $code();
+            $fxResult = $fx();
         } catch (\Throwable $exception) {
-            $codeException = $exception;
+            $fxException = $exception;
 
             throw $exception;
         } finally {
             try {
                 $this->unlock();
             } catch (LockReleaseException $lockReleaseException) {
-                $lockReleaseException->setCodeResult($codeResult);
+                $lockReleaseException->setCodeResult($fxResult);
 
-                if ($codeException !== null) {
-                    $lockReleaseException->setCodeException($codeException);
+                if ($fxException !== null) {
+                    $lockReleaseException->setCodeException($fxException);
                 }
 
                 throw $lockReleaseException;
             }
         }
 
-        return $codeResult;
+        return $fxResult;
     }
 }

--- a/src/Mutex/AbstractLockMutex.php
+++ b/src/Mutex/AbstractLockMutex.php
@@ -19,14 +19,14 @@ abstract class AbstractLockMutex extends AbstractMutex
      *
      * This method blocks until the lock was acquired.
      *
-     * @throws LockAcquireException The lock could not be acquired
+     * @throws LockAcquireException
      */
     abstract protected function lock(): void;
 
     /**
      * Release the lock.
      *
-     * @throws LockReleaseException The lock could not be released
+     * @throws LockReleaseException
      */
     abstract protected function unlock(): void;
 

--- a/src/Mutex/AbstractLockMutex.php
+++ b/src/Mutex/AbstractLockMutex.php
@@ -39,10 +39,8 @@ abstract class AbstractLockMutex extends AbstractMutex
         $fxException = null;
         try {
             $fxResult = $fx();
-        } catch (\Throwable $exception) {
-            $fxException = $exception;
-
-            throw $exception;
+        } catch (\Throwable $fxException) {
+            throw $fxException;
         } finally {
             try {
                 $this->unlock();

--- a/src/Mutex/AbstractRedlockMutex.php
+++ b/src/Mutex/AbstractRedlockMutex.php
@@ -32,11 +32,11 @@ abstract class AbstractRedlockMutex extends AbstractSpinlockMutex implements Log
      * called already.
      *
      * @param array<int, TClient> $clients
-     * @param float               $timeout In seconds
+     * @param float               $acquireTimeout In seconds
      */
-    public function __construct(array $clients, string $name, float $timeout = 3)
+    public function __construct(array $clients, string $name, float $acquireTimeout = 3)
     {
-        parent::__construct($name, $timeout);
+        parent::__construct($name, $acquireTimeout);
 
         $this->clients = $clients;
         $this->logger = new NullLogger();

--- a/src/Mutex/AbstractRedlockMutex.php
+++ b/src/Mutex/AbstractRedlockMutex.php
@@ -32,7 +32,7 @@ abstract class AbstractRedlockMutex extends AbstractSpinlockMutex implements Log
      * called already.
      *
      * @param array<int, TClient> $clients
-     * @param float               $timeout The timeout in seconds a lock expires
+     * @param float               $timeout In seconds
      */
     public function __construct(array $clients, string $name, float $timeout = 3)
     {

--- a/src/Mutex/AbstractSpinlockMutex.php
+++ b/src/Mutex/AbstractSpinlockMutex.php
@@ -79,7 +79,7 @@ abstract class AbstractSpinlockMutex extends AbstractLockMutex
      *
      * @return bool True if the lock was acquired
      *
-     * @throws LockAcquireException an unexpected error happened
+     * @throws LockAcquireException An unexpected error happened
      */
     abstract protected function acquire(string $key, float $expire): bool;
 

--- a/src/Mutex/AbstractSpinlockMutex.php
+++ b/src/Mutex/AbstractSpinlockMutex.php
@@ -26,7 +26,7 @@ abstract class AbstractSpinlockMutex extends AbstractLockMutex
     private ?float $acquiredTs = null;
 
     /**
-     * @param float $timeout The timeout in seconds a lock expires
+     * @param float $timeout In seconds
      */
     public function __construct(string $name, float $timeout = 3)
     {
@@ -75,7 +75,7 @@ abstract class AbstractSpinlockMutex extends AbstractLockMutex
     /**
      * Try to acquire a lock.
      *
-     * @param float $expire The timeout in seconds when a lock expires
+     * @param float $expire In seconds
      *
      * @return bool True if the lock was acquired
      *

--- a/src/Mutex/FlockMutex.php
+++ b/src/Mutex/FlockMutex.php
@@ -62,9 +62,6 @@ class FlockMutex extends AbstractLockMutex
         return self::STRATEGY_LOOP;
     }
 
-    /**
-     * @throws LockAcquireException
-     */
     private function lockBlocking(): void
     {
         if (!flock($this->fileHandle, \LOCK_EX)) {
@@ -72,10 +69,6 @@ class FlockMutex extends AbstractLockMutex
         }
     }
 
-    /**
-     * @throws LockAcquireException
-     * @throws LockAcquireTimeoutException
-     */
     private function lockPcntl(): void
     {
         $timeoutInt = (int) ceil($this->timeout);
@@ -93,10 +86,6 @@ class FlockMutex extends AbstractLockMutex
         }
     }
 
-    /**
-     * @throws LockAcquireTimeoutException
-     * @throws LockAcquireException
-     */
     private function lockBusy(): void
     {
         $loop = new Loop();
@@ -108,9 +97,6 @@ class FlockMutex extends AbstractLockMutex
         }, $this->timeout);
     }
 
-    /**
-     * @throws LockAcquireException
-     */
     private function acquireNonBlockingLock(): bool
     {
         if (!flock($this->fileHandle, \LOCK_EX | \LOCK_NB, $wouldBlock)) {
@@ -125,10 +111,6 @@ class FlockMutex extends AbstractLockMutex
         return true;
     }
 
-    /**
-     * @throws LockAcquireException
-     * @throws LockAcquireTimeoutException
-     */
     #[\Override]
     protected function lock(): void
     {

--- a/src/Mutex/FlockMutex.php
+++ b/src/Mutex/FlockMutex.php
@@ -8,6 +8,7 @@ use Malkusch\Lock\Exception\DeadlineException;
 use Malkusch\Lock\Exception\LockAcquireException;
 use Malkusch\Lock\Exception\LockAcquireTimeoutException;
 use Malkusch\Lock\Exception\LockReleaseException;
+use Malkusch\Lock\Util\LockUtil;
 use Malkusch\Lock\Util\Loop;
 use Malkusch\Lock\Util\PcntlTimeout;
 
@@ -70,7 +71,7 @@ class FlockMutex extends AbstractLockMutex
 
     private function lockPcntl(): void
     {
-        $acquireTimeoutInt = (int) ceil($this->acquireTimeout);
+        $acquireTimeoutInt = LockUtil::getInstance()->castFloatToInt(ceil($this->acquireTimeout));
 
         $timebox = new PcntlTimeout($acquireTimeoutInt);
 

--- a/src/Mutex/FlockMutex.php
+++ b/src/Mutex/FlockMutex.php
@@ -17,8 +17,6 @@ use Malkusch\Lock\Util\PcntlTimeout;
  */
 class FlockMutex extends AbstractLockMutex
 {
-    public const INFINITE_TIMEOUT = -1.0;
-
     private const STRATEGY_BLOCK = 'block';
     private const STRATEGY_PCNTL = 'pcntl';
     private const STRATEGY_LOOP = 'loop';
@@ -35,7 +33,7 @@ class FlockMutex extends AbstractLockMutex
      * @param resource $fileHandle
      * @param float    $acquireTimeout In seconds
      */
-    public function __construct($fileHandle, float $acquireTimeout = self::INFINITE_TIMEOUT)
+    public function __construct($fileHandle, float $acquireTimeout = \INF)
     {
         if (!is_resource($fileHandle)) {
             throw new \InvalidArgumentException('The file handle is not a valid resource');
@@ -51,7 +49,7 @@ class FlockMutex extends AbstractLockMutex
      */
     private function determineLockingStrategy(): string
     {
-        if ($this->acquireTimeout === self::INFINITE_TIMEOUT) {
+        if ($this->acquireTimeout > 100 * 365.25 * 24 * 60 * 60) { // 100 years
             return self::STRATEGY_BLOCK;
         }
 

--- a/src/Mutex/MemcachedMutex.php
+++ b/src/Mutex/MemcachedMutex.php
@@ -15,11 +15,11 @@ class MemcachedMutex extends AbstractSpinlockMutex
      * The Memcached API needs to have at least one server in its pool. I.e.
      * it has to be added with Memcached::addServer().
      *
-     * @param float $timeout In seconds
+     * @param float $acquireTimeout In seconds
      */
-    public function __construct(string $name, \Memcached $memcached, float $timeout = 3)
+    public function __construct(string $name, \Memcached $memcached, float $acquireTimeout = 3)
     {
-        parent::__construct($name, $timeout);
+        parent::__construct($name, $acquireTimeout);
 
         $this->memcached = $memcached;
     }

--- a/src/Mutex/MemcachedMutex.php
+++ b/src/Mutex/MemcachedMutex.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Malkusch\Lock\Mutex;
 
+use Malkusch\Lock\Util\LockUtil;
+
 /**
  * Memcached based spinlock implementation.
  */
@@ -29,7 +31,7 @@ class MemcachedMutex extends AbstractSpinlockMutex
     {
         // memcached supports only integer expire
         // https://github.com/memcached/memcached/wiki/Commands#standard-protocol
-        $expireInt = (int) ceil($expire);
+        $expireInt = LockUtil::getInstance()->castFloatToInt(ceil($expire));
 
         return $this->memcached->add($key, true, $expireInt);
     }

--- a/src/Mutex/MemcachedMutex.php
+++ b/src/Mutex/MemcachedMutex.php
@@ -15,8 +15,7 @@ class MemcachedMutex extends AbstractSpinlockMutex
      * The Memcached API needs to have at least one server in its pool. I.e.
      * it has to be added with Memcached::addServer().
      *
-     * @param string $name    The lock name
-     * @param float  $timeout The timeout in seconds a lock expires
+     * @param float $timeout In seconds
      */
     public function __construct(string $name, \Memcached $memcached, float $timeout = 3)
     {

--- a/src/Mutex/Mutex.php
+++ b/src/Mutex/Mutex.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Malkusch\Lock\Mutex;
 
-use Malkusch\Lock\Exception\ExecutionOutsideLockException;
 use Malkusch\Lock\Exception\LockAcquireException;
 use Malkusch\Lock\Exception\LockReleaseException;
 use Malkusch\Lock\Util\DoubleCheckedLocking;
@@ -30,10 +29,9 @@ interface Mutex
      *
      * @return T
      *
-     * @throws \Throwable                    The execution callback threw an exception
-     * @throws LockAcquireException          The mutex could not be acquired, no further side effects
-     * @throws LockReleaseException          The mutex could not be released, the code was already executed
-     * @throws ExecutionOutsideLockException Some code has been executed outside of the lock
+     * @throws \Throwable
+     * @throws LockAcquireException
+     * @throws LockReleaseException
      */
     public function synchronized(callable $code);
 

--- a/src/Mutex/Mutex.php
+++ b/src/Mutex/Mutex.php
@@ -30,7 +30,7 @@ interface Mutex
      *
      * @return T
      *
-     * @throws \Exception                    The execution callback threw an exception
+     * @throws \Throwable                    The execution callback threw an exception
      * @throws LockAcquireException          The mutex could not be acquired, no further side effects
      * @throws LockReleaseException          The mutex could not be released, the code was already executed
      * @throws ExecutionOutsideLockException Some code has been executed outside of the lock

--- a/src/Mutex/MySQLMutex.php
+++ b/src/Mutex/MySQLMutex.php
@@ -14,6 +14,7 @@ class MySQLMutex extends AbstractLockMutex
 
     private string $name;
 
+    /** In seconds */
     private float $timeout;
 
     /**

--- a/src/Mutex/MySQLMutex.php
+++ b/src/Mutex/MySQLMutex.php
@@ -15,12 +15,12 @@ class MySQLMutex extends AbstractLockMutex
     private string $name;
 
     /** In seconds */
-    private float $timeout;
+    private float $acquireTimeout;
 
     /**
-     * @param float $timeout In seconds
+     * @param float $acquireTimeout In seconds
      */
-    public function __construct(\PDO $PDO, string $name, float $timeout = 0)
+    public function __construct(\PDO $PDO, string $name, float $acquireTimeout = 0)
     {
         $this->pdo = $PDO;
 
@@ -31,7 +31,7 @@ class MySQLMutex extends AbstractLockMutex
         }
 
         $this->name = $namePrefix . $name;
-        $this->timeout = $timeout;
+        $this->acquireTimeout = $acquireTimeout;
     }
 
     #[\Override]
@@ -43,11 +43,11 @@ class MySQLMutex extends AbstractLockMutex
         // TODO MariaDB supports microseconds precision since 10.1.2 version,
         // but we need to detect the support reliably first
         // https://github.com/MariaDB/server/commit/3e792e6cbccb5d7bf5b84b38336f8a40ad232020
-        $timeoutInt = (int) ceil($this->timeout);
+        $acquireTimeoutInt = (int) ceil($this->acquireTimeout);
 
         $statement->execute([
             $this->name,
-            $timeoutInt,
+            $acquireTimeoutInt,
         ]);
 
         $statement->setFetchMode(\PDO::FETCH_NUM);
@@ -63,7 +63,7 @@ class MySQLMutex extends AbstractLockMutex
             throw new LockAcquireException('An error occurred while acquiring the lock');
         }
 
-        throw LockAcquireTimeoutException::create($this->timeout);
+        throw LockAcquireTimeoutException::create($this->acquireTimeout);
     }
 
     #[\Override]

--- a/src/Mutex/MySQLMutex.php
+++ b/src/Mutex/MySQLMutex.php
@@ -43,7 +43,7 @@ class MySQLMutex extends AbstractLockMutex
         // TODO MariaDB supports microseconds precision since 10.1.2 version,
         // but we need to detect the support reliably first
         // https://github.com/MariaDB/server/commit/3e792e6cbccb5d7bf5b84b38336f8a40ad232020
-        $acquireTimeoutInt = (int) ceil($this->acquireTimeout);
+        $acquireTimeoutInt = LockUtil::getInstance()->castFloatToInt(ceil($this->acquireTimeout));
 
         $statement->execute([
             $this->name,

--- a/src/Mutex/RedisMutex.php
+++ b/src/Mutex/RedisMutex.php
@@ -6,6 +6,7 @@ namespace Malkusch\Lock\Mutex;
 
 use Malkusch\Lock\Exception\LockAcquireException;
 use Malkusch\Lock\Exception\LockReleaseException;
+use Malkusch\Lock\Util\LockUtil;
 use Predis\ClientInterface as PredisClientInterface;
 use Predis\PredisException;
 
@@ -40,7 +41,7 @@ class RedisMutex extends AbstractRedlockMutex
     #[\Override]
     protected function add(object $client, string $key, string $value, float $expire): bool
     {
-        $expireMillis = (int) ceil($expire * 1000);
+        $expireMillis = LockUtil::getInstance()->castFloatToInt(ceil($expire * 1000));
 
         if ($this->isClientPHPRedis($client)) {
             try {

--- a/src/Mutex/TransactionalMutex.php
+++ b/src/Mutex/TransactionalMutex.php
@@ -129,7 +129,7 @@ class TransactionalMutex extends AbstractMutex
     /**
      * Rolls back a transaction.
      *
-     * @throws LockAcquireException The roll back failed
+     * @throws LockAcquireException
      */
     private function rollBack(\Throwable $exception): void
     {

--- a/src/Mutex/TransactionalMutex.php
+++ b/src/Mutex/TransactionalMutex.php
@@ -135,9 +135,9 @@ class TransactionalMutex extends AbstractMutex
     {
         try {
             $this->pdo->rollBack();
-        } catch (\PDOException $e2) {
+        } catch (\PDOException $e) {
             throw new LockAcquireException(
-                'Could not roll back transaction: ' . $e2->getMessage(),
+                'Could not roll back transaction: ' . $e->getMessage(),
                 0,
                 $exception
             );

--- a/src/Util/DoubleCheckedLocking.php
+++ b/src/Util/DoubleCheckedLocking.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Malkusch\Lock\Util;
 
-use Malkusch\Lock\Exception\ExecutionOutsideLockException;
 use Malkusch\Lock\Exception\LockAcquireException;
 use Malkusch\Lock\Exception\LockReleaseException;
 use Malkusch\Lock\Mutex\Mutex;
@@ -50,10 +49,9 @@ class DoubleCheckedLocking
      *
      * @return T|false False if check did not pass
      *
-     * @throws \Exception                    The execution callback or the check threw an exception
-     * @throws LockAcquireException          The mutex could not be acquired
-     * @throws LockReleaseException          The mutex could not be released
-     * @throws ExecutionOutsideLockException Some code has been executed outside of the lock
+     * @throws \Throwable
+     * @throws LockAcquireException
+     * @throws LockReleaseException
      */
     public function then(callable $code)
     {

--- a/src/Util/LockUtil.php
+++ b/src/Util/LockUtil.php
@@ -54,6 +54,18 @@ class LockUtil
             . $this->makeRandomToken() . '.txt';
     }
 
+    public function castFloatToInt(float $value): int
+    {
+        \assert(!\is_nan($value));
+
+        // https://github.com/php/php-src/issues/17081
+        return ($value > \PHP_INT_MIN && $value < \PHP_INT_MAX)
+            ? (int) round($value)
+            : ($value < 0
+                ? \PHP_INT_MIN
+                : \PHP_INT_MAX);
+    }
+
     /**
      * @return non-empty-string
      */

--- a/src/Util/Loop.php
+++ b/src/Util/Loop.php
@@ -47,8 +47,8 @@ class Loop
      *
      * @return T
      *
-     * @throws \Throwable                  The execution callback threw an exception
-     * @throws LockAcquireTimeoutException The timeout has been reached
+     * @throws \Throwable
+     * @throws LockAcquireTimeoutException
      */
     public function execute(callable $code, float $timeout)
     {

--- a/src/Util/Loop.php
+++ b/src/Util/Loop.php
@@ -75,7 +75,7 @@ class Loop
             }
 
             // Calculate max time remaining, don't sleep any longer than that.
-            $usecRemaining = (int) (($deadlineTs - microtime(true)) * 1e6);
+            $usecRemaining = LockUtil::getInstance()->castFloatToInt(($deadlineTs - microtime(true)) * 1e6);
 
             // We've ran out of time.
             if ($usecRemaining <= 0) {

--- a/src/Util/Loop.php
+++ b/src/Util/Loop.php
@@ -47,7 +47,7 @@ class Loop
      *
      * @return T
      *
-     * @throws \Exception                  The execution callback threw an exception
+     * @throws \Throwable                  The execution callback threw an exception
      * @throws LockAcquireTimeoutException The timeout has been reached
      */
     public function execute(callable $code, float $timeout)

--- a/tests/Mutex/AbstractRedlockMutexTest.php
+++ b/tests/Mutex/AbstractRedlockMutexTest.php
@@ -170,8 +170,8 @@ class AbstractRedlockMutexTest extends TestCase
      * Tests acquiring keys takes too long.
      *
      * @param int   $count   The total count of servers
-     * @param float $timeout The timeout in seconds
-     * @param float $delay   The delay in seconds
+     * @param float $timeout In seconds
+     * @param float $delay   In seconds
      *
      * @dataProvider provideAcquireTimeoutsCases
      */

--- a/tests/Util/LockUtilTest.php
+++ b/tests/Util/LockUtilTest.php
@@ -57,6 +57,37 @@ class LockUtilTest extends TestCase
     }
 
     /**
+     * @dataProvider provideCastFloatToIntCases
+     */
+    #[DataProvider('provideCastFloatToIntCases')]
+    public function testCastFloatToInt(int $expectedResult, float $value): void
+    {
+        self::assertSame($expectedResult, LockUtil::getInstance()->castFloatToInt($value));
+    }
+
+    /**
+     * @return iterable<list<mixed>>
+     */
+    public static function provideCastFloatToIntCases(): iterable
+    {
+        yield [10, 10];
+        yield [0, 0];
+        yield [0, -0.0];
+        yield [0, 0.49];
+        yield [0, -0.49];
+        yield [1, 0.5];
+        yield [-1, -0.5];
+        yield [1020304050607080, 1020304050607080];
+        yield [-1020304050607080, -1020304050607080];
+        yield [\PHP_INT_MAX, \PHP_INT_MAX];
+        yield [\PHP_INT_MIN, \PHP_INT_MIN];
+        yield [\PHP_INT_MAX, (float) \PHP_INT_MAX + 2000];
+        yield [\PHP_INT_MIN, (float) \PHP_INT_MIN - 2000];
+        yield [\PHP_INT_MAX, \INF];
+        yield [\PHP_INT_MIN, -\INF];
+    }
+
+    /**
      * @dataProvider provideFormatTimeoutCases
      */
     #[DataProvider('provideFormatTimeoutCases')]


### PR DESCRIPTION
### BC break: `FlockMutex::INFINITE_TIMEOUT` constant was removed

The original `-1.0` value is no longer supported. Use `\INF` instead.