### PR TITLE
Make AbstractLockMutex and Loop classes non-internal

### DIFF
--- a/src/Mutex/AbstractLockMutex.php
+++ b/src/Mutex/AbstractLockMutex.php
@@ -7,9 +7,6 @@ namespace Malkusch\Lock\Mutex;
 use Malkusch\Lock\Exception\LockAcquireException;
 use Malkusch\Lock\Exception\LockReleaseException;
 
-/**
- * @internal
- */
 abstract class AbstractLockMutex extends AbstractMutex
 {
     /**

--- a/src/Util/Loop.php
+++ b/src/Util/Loop.php
@@ -8,8 +8,6 @@ use Malkusch\Lock\Exception\LockAcquireTimeoutException;
 
 /**
  * Repeats executing a code until it was successful.
- *
- * @internal
  */
 class Loop
 {


### PR DESCRIPTION
Because PHPStan considers all methods inherited from internal class internal - https://github.com/phpstan/phpstan/issues/13038